### PR TITLE
Update 01-run-application.adoc

### DIFF
--- a/documentation/modules/ROOT/pages/01-run-application.adoc
+++ b/documentation/modules/ROOT/pages/01-run-application.adoc
@@ -17,7 +17,7 @@ First, you need to clone the https://github.com/thoth-station/cli-examples/[thot
 [.lines_space]
 [.console-input]
 [source,bash]
-git clone https://github.com/thoth-station/cli-example.git && cd cli-example
+git clone https://github.com/thoth-station/cli-examples.git && cd cli-examples
 pip3 install thamos
 thamos --help
 


### PR DESCRIPTION
Editorial fix, the name of the project with the examples ends with an "s" letter that is cli-examples instead of cli-example